### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/2020-02/Github actions 自动集成.md
+++ b/2020-02/Github actions 自动集成.md
@@ -66,7 +66,7 @@ jobs:
       - name: Build
         run: make build # 运行Makefile里的编译任务出可执行文件
       - name: Docker Publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kicoe/test
           username: kicoe


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore